### PR TITLE
fix csslint style

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,7 @@ gulp.task('{cssTask}',function(){
         <!-- END useCmq:veil -->
         <!-- BEGIN useCssLint:veil -->
         .pipe(csslint())
-        .pipe(csslint.reporter())
+        .pipe(csslint.formatter())
         <!-- END useCssLint:veil -->
         <!-- BEGIN useConcatCss:veil -->
         .pipe(concat('{concatCss}'))


### PR DESCRIPTION
`csslint.reporter()` to `csslint.formatter()`

gulp-csslint has changed from `reporter` to `formatter` in past revisions.
https://github.com/lazd/gulp-csslint/commit/17d99d61c111ce09524f34efeebaf3246eff0372